### PR TITLE
MD5.xs: silence possible loss of data warnings on Win32

### DIFF
--- a/MD5.xs
+++ b/MD5.xs
@@ -760,10 +760,10 @@ context(ctx, ...)
 	    XSRETURN(0);
 	}
 
-        w=ctx->A; out[ 0]=w; out[ 1]=(w>>8); out[ 2]=(w>>16); out[ 3]=(w>>24);
-        w=ctx->B; out[ 4]=w; out[ 5]=(w>>8); out[ 6]=(w>>16); out[ 7]=(w>>24);
-        w=ctx->C; out[ 8]=w; out[ 9]=(w>>8); out[10]=(w>>16); out[11]=(w>>24);
-        w=ctx->D; out[12]=w; out[13]=(w>>8); out[14]=(w>>16); out[15]=(w>>24);
+        w=ctx->A; out[ 0]=(char)w; out[ 1]=(char)(w>>8); out[ 2]=(char)(w>>16); out[ 3]=(char)(w>>24);
+        w=ctx->B; out[ 4]=(char)w; out[ 5]=(char)(w>>8); out[ 6]=(char)(w>>16); out[ 7]=(char)(w>>24);
+        w=ctx->C; out[ 8]=(char)w; out[ 9]=(char)(w>>8); out[10]=(char)(w>>16); out[11]=(char)(w>>24);
+        w=ctx->D; out[12]=(char)w; out[13]=(char)(w>>8); out[14]=(char)(w>>16); out[15]=(char)(w>>24);
 
 	EXTEND(SP, 3);
 	ST(0) = sv_2mortal(newSVuv(ctx->bytes_high << 26 |

--- a/t/files.t
+++ b/t/files.t
@@ -15,14 +15,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-60a80f534f0017745eb755f36a946fe7  MD5.xs
+78a40477943a50bb602307a8c1c55032  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-9572832f3628e3bebcdd54f47c43dc5a  MD5.xs
+404a8da4c1fd745af0e41754d67b2050  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }


### PR DESCRIPTION
When building Perl on Win32 we see warnings like this:

    MD5.xs(723) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data
    MD5.xs(723) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data
    MD5.xs(723) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data
    MD5.xs(724) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data
    MD5.xs(724) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data
    MD5.xs(724) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data
    MD5.xs(725) : warning C4244: '=' : conversion from 'U32' to 'char', possible loss of data

We would like Perl to build without warnings on all platforms so we
would like to get these warnings silenced. You don't see them on gcc
builds as gcc has different ideas about what to warn for in these cases.
You can enable -Wconversion but it complains about a ton of stuff that
VC wouldn't. Generally VC warnings are at least plausibly mistakes,
the -Wconversion ones are mostly things that are not. :-(