### PR TITLE
Preserve OPTIMIZE in hints

### DIFF
--- a/hints/irix_6.pl
+++ b/hints/irix_6.pl
@@ -3,6 +3,8 @@
 
 use strict;
 no strict 'vars';
-if ($Config{cc} =~ /64|n32/ && `$Config{cc} -version 2>&1` =~ /\s7\.1/) {
-    $self->{OPTIMIZE} = "-O1";
+if ( $Config{cc} =~ /64|n32/ && `$Config{cc} -version 2>&1` =~ /\s7\.1/ ) {
+    my $optimize = $Config{optimize};
+    $optimize =~ s/(^| )-O[2-9]\b/$1-O1/g
+      and $self->{OPTIMIZE} = $optimize;
 }


### PR DESCRIPTION
Fixes #5 

The irix_6 hints file forcefully overwrite OPTIMIZE in order to work around
a compiler mishap with high level optimizations. However, this loses
whatever extra flags are listed in OPTIMIZE, such as compiler warnings
flags or PERL_POISON, and makes the module difficult to run under a
debugger since a minimal level of optimization is always enforced. This may
also cause loading errors with the new XS handshake facility.

Instead, we chose to just follow Storable's strategy of lowering the
optimization level with a substitution, while keeping all the other flags
untouched. If other compiler flags are deemed problematic (such as
-mcpu/-march on gcc), they ought to be addressed separately.