### PR TITLE
MD5.xs - remove meaningless type qualifier on cast type

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+2.59 Thurs March 23 2023
+- Remove meaningless const type qualifier to silence HPUX builds.
+
 2.58 Mon Oct 5 2020
 - Update repo location.
 - Update recent changelog entries. Let's see if that's enough to make metacpan happy.

--- a/MD5.pm
+++ b/MD5.pm
@@ -3,7 +3,7 @@ package Digest::MD5;
 use strict;
 use warnings;
 
-our $VERSION = '2.58';
+our $VERSION = '2.59';
 
 require Exporter;
 *import = \&Exporter::import;

--- a/MD5.xs
+++ b/MD5.xs
@@ -467,7 +467,7 @@ static MD5_CTX* get_md5_ctx(pTHX_ SV* sv)
 
     for (mg = SvMAGIC(SvRV(sv)); mg; mg = mg->mg_moremagic) {
 	if (mg->mg_type == PERL_MAGIC_ext
-	    && mg->mg_virtual == (const MGVTBL * const)&vtbl_md5) {
+	    && mg->mg_virtual == (const MGVTBL *)&vtbl_md5) {
 	    return (MD5_CTX *)mg->mg_ptr;
 	}
     }
@@ -489,7 +489,7 @@ static SV * new_md5_ctx(pTHX_ MD5_CTX *context, const char *klass)
 #ifdef USE_ITHREADS
     mg =
 #endif
-	sv_magicext(sv, NULL, PERL_MAGIC_ext, (const MGVTBL * const)&vtbl_md5, (const char *)context, 0);
+	sv_magicext(sv, NULL, PERL_MAGIC_ext, (const MGVTBL *)&vtbl_md5, (const char *)context, 0);
 
 #if defined(USE_ITHREADS) && defined(MGf_DUP)
     mg->mg_flags |= MGf_DUP;

--- a/t/files.t
+++ b/t/files.t
@@ -15,14 +15,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-3fce99bf3f4df26d65843a6990849df0  MD5.xs
+f9d533188a37309320d2805372db0b0e  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-3fce99bf3f4df26d65843a6990849df0  MD5.xs
+3813818ce6d722a3fee7f7cd9e89bac0  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }
@@ -163,4 +163,3 @@ sub cat_file
     close(FILE);
     $tmp;
 }
-


### PR DESCRIPTION
On the HPUX Itanium compiler (which is very picky), we get warnings about the second "const" in these casts. Removing them makes the compiler happy doesn't seem to do any harm.

"MD5.xs", line 470: warning #2191-D: type qualifier is meaningless on cast type
            && mg->mg_virtual == (const MGVTBL * const)&vtbl_md5) {
                                  ^

"MD5.xs", line 492: warning #2191-D: type qualifier is meaningless on cast type
        sv_magicext(sv, NULL, PERL_MAGIC_ext, (const MGVTBL * const)&vtbl_md5, (const char *)context, 0);

Includes a version bump to 2.59, Changes update and test updates.