### PR TITLE
MD5.xs: eliminate C++ guards

### DIFF
--- a/MD5.xs
+++ b/MD5.xs
@@ -32,16 +32,10 @@
  * documentation and/or software.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #define PERL_NO_GET_CONTEXT     /* we want efficiency */
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#ifdef __cplusplus
-}
-#endif
 
 #ifndef PERL_UNUSED_VAR
 # define PERL_UNUSED_VAR(x) ((void)x)

--- a/t/files.t
+++ b/t/files.t
@@ -22,7 +22,7 @@ EOT
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-3fce99bf3f4df26d65843a6990849df0  MD5.xs
+f8549bd328fa712f4af41430738c285a  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }


### PR DESCRIPTION
These aren't needed with modern perls, and it's only useful to build modern perls as C++.

This was causing an error in a system header when building blead as C++ with MSVC:

    C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\um\wspiapi.h(53):
    error C2894: templates cannot be declared to have 'C' linkage

See https://github.com/Perl/perl5/issues/21073 for more information